### PR TITLE
Add Molecule tests, change handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,15 @@
 ---
+os: linux
+dist: focal
 language: python
-python: "2.7"
-
-# Use the new container infrastructure
-sudo: required
-dist: trusty
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
-
+python: 3.8
+services:
+  - docker
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
-
+  - python3 -m pip install molecule
+  - python3 -m pip install molecule-docker
+  - python3 -m pip install ansible
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
-
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  - molecule --version
+  - molecule test # default scenario with ring topology
+  - molecule test -s star

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
-# defaults file for tinc
-
-service_name: "{{ tinc_service_name }}"
+tinc_netname: tinc-vpn
+tinc_control_plane_bind_ip: "{{ ansible_eth0.ipv4.address }}"
 tinc_service_name: tinc
 # OpenWRT package manager does not support state: latest
 tinc_package_state: present

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,18 +1,15 @@
 ---
-# handlers file for tinc
+- name: restart service
+  service:
+    name: "{{ tinc_service_name }}"
+    state: restarted
+    enabled: yes
+  when: ansible_service_mgr != "systemd"
 
-#- name: Restart Service
-#  service:
-#    name: "{{ service_name }}"
-#    daemon_reload: "{{ ansible_service_mgr == 'systemd' | ternary('yes',omit) }}"
-#    state: restarted
-
-- name: Restart Service
+- name: restart service with systemd
   systemd:
    daemon_reload: yes
+   name: "{{ tinc_service_name }}"
+   state: restarted
+   enabled: yes
   when: ansible_service_mgr == "systemd"
-
-- name: Restart Service
-  service:
-    name: "{{ service_name }}"
-    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -126,21 +126,10 @@ galaxy_info:
   #  - 9.3
   - name: Ubuntu
     versions:
-  #  - all
-  #  - lucid
-  #  - maverick
-  #  - natty
-  #  - oneiric
-  #  - precise
-  #  - quantal
-  #  - raring
-  #  - saucy
     - trusty
-  #  - utopic
-  #  - vivid
-  #  - wily
     - xenial
-  #  - yakkety
+    - bionic
+    - focal
   #- name: Debian
   #  versions:
   #  - all
@@ -157,10 +146,8 @@ galaxy_info:
   #  - any
   - name: EL
     versions:
-  #  - all
-  #  - 5
-  #  - 6
     - 7
+    - 8
   #- name: Windows
   #  versions:
   #  - all

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,32 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+
+  - name: Debian - apt update, install rsync and ping
+    when: ansible_os_family == "Debian"
+    apt:
+      update_cache: yes
+      name:
+        - rsync
+        - inetutils-ping
+      state: present
+
+  - name: CentOS 7 - get iproute to fix undefined ansible_default_ipv4.address
+    yum:
+      name: iproute
+      state: present
+    when:
+      - ansible_distribution == "CentOS"
+      - ansible_distribution_major_version == "7"
+
+  - name: CentOS 7 - re-collect network facts
+    setup:
+      gather_subset: network
+    when:
+      - ansible_distribution == "CentOS"
+      - ansible_distribution_major_version == "7"
+
+  - name: Include ansible-tinc
+    include_role:
+      name: ansible-tinc

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,94 @@
+---
+scenario:
+  name: default # ring topology
+dependency:
+  name: galaxy
+driver:
+  name: docker
+verifier:
+  name: ansible
+provisioner:
+  name: ansible
+  log: false
+  inventory:
+    host_vars:
+      tinc-ubuntu-16:
+        tinc_vpn_ip: 10.10.0.11
+      tinc-ubuntu-18:
+        tinc_vpn_ip: 10.10.0.12
+      tinc-ubuntu-20:
+        tinc_vpn_ip: 10.10.0.13
+      tinc-centos-7:
+        tinc_vpn_ip: 10.10.0.14
+      tinc-centos-8:
+        tinc_vpn_ip: 10.10.0.15
+platforms:
+  - name: tinc-centos-7
+    image: docker.io/pycontribs/centos:7
+    pre_build_image: true
+    privileged: true
+    command: /sbin/init
+    etc_hosts:
+      tinc-ubuntu-16: 10.10.0.11
+      tinc-ubuntu-18: 10.10.0.12
+      tinc-ubuntu-20: 10.10.0.13
+      tinc-centos-7:  10.10.0.14
+      tinc-centos-8:  10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes
+  - name: tinc-centos-8
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+    privileged: true
+    command: /sbin/init
+    etc_hosts:
+      tinc-ubuntu-16: 10.10.0.11
+      tinc-ubuntu-18: 10.10.0.12
+      tinc-ubuntu-20: 10.10.0.13
+      tinc-centos-7:  10.10.0.14
+      tinc-centos-8:  10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes
+  - name: tinc-ubuntu-16
+    image: docker.io/library/ubuntu:16.04
+    privileged: true
+    etc_hosts:
+      tinc-ubuntu-16: 10.10.0.11
+      tinc-ubuntu-18: 10.10.0.12
+      tinc-ubuntu-20: 10.10.0.13
+      tinc-centos-7:  10.10.0.14
+      tinc-centos-8:  10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes
+  - name: tinc-ubuntu-18
+    image: docker.io/library/ubuntu:18.04
+    privileged: true
+    etc_hosts:
+      tinc-ubuntu-16: 10.10.0.11
+      tinc-ubuntu-18: 10.10.0.12
+      tinc-ubuntu-20: 10.10.0.13
+      tinc-centos-7:  10.10.0.14
+      tinc-centos-8:  10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes
+  - name: tinc-ubuntu-20
+    image: docker.io/library/ubuntu:20.04
+    privileged: true
+    etc_hosts:
+      tinc-ubuntu-16: 10.10.0.11
+      tinc-ubuntu-18: 10.10.0.12
+      tinc-ubuntu-20: 10.10.0.13
+      tinc-centos-7:  10.10.0.14
+      tinc-centos-8:  10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: no
+  tasks:
+
+  - name: Ping other nodes over VPN
+    command: "ping -c 1 {{ item }}"
+    with_items: "{{ play_hosts }}"

--- a/molecule/star/converge.yml
+++ b/molecule/star/converge.yml
@@ -1,0 +1,1 @@
+../default/converge.yml

--- a/molecule/star/molecule.yml
+++ b/molecule/star/molecule.yml
@@ -1,0 +1,93 @@
+---
+scenario:
+  name: star
+dependency:
+  name: galaxy
+driver:
+  name: docker
+verifier:
+  name: ansible
+provisioner:
+  name: ansible
+  log: false
+  inventory:
+    host_vars:
+      tinc-ubuntu-16:
+        tinc_vpn_ip: 10.10.0.11
+      tinc-ubuntu-18:
+        tinc_vpn_ip: 10.10.0.12
+      tinc-ubuntu-20:
+        tinc_vpn_ip: 10.10.0.13
+      tinc-centos-7:
+        tinc_vpn_ip: 10.10.0.14
+      tinc-centos-8:
+        tinc_vpn_ip: 10.10.0.15
+platforms:
+  - name: tinc-centos-7
+    image: docker.io/pycontribs/centos:7
+    pre_build_image: true
+    privileged: true
+    command: /sbin/init
+    etc_hosts:
+      tinc-ubuntu-16: 10.10.0.11
+      tinc-ubuntu-18: 10.10.0.12
+      tinc-ubuntu-20: 10.10.0.13
+      tinc-centos-7:  10.10.0.14
+      tinc-centos-8:  10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes
+  - name: tinc-centos-8
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+    privileged: true
+    command: /sbin/init
+    etc_hosts:
+      tinc-ubuntu-16: 10.10.0.11
+      tinc-ubuntu-18: 10.10.0.12
+      tinc-ubuntu-20: 10.10.0.13
+      tinc-centos-7:  10.10.0.14
+      tinc-centos-8:  10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_leaf_nodes
+
+  - name: tinc-ubuntu-16
+    image: docker.io/library/ubuntu:16.04
+    privileged: true
+    etc_hosts:
+      tinc-ubuntu-16: 10.10.0.11
+      tinc-ubuntu-18: 10.10.0.12
+      tinc-ubuntu-20: 10.10.0.13
+      tinc-centos-7:  10.10.0.14
+      tinc-centos-8:  10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_leaf_nodes
+
+  - name: tinc-ubuntu-18
+    image: docker.io/library/ubuntu:18.04
+    privileged: true
+    etc_hosts:
+      tinc-ubuntu-16: 10.10.0.11
+      tinc-ubuntu-18: 10.10.0.12
+      tinc-ubuntu-20: 10.10.0.13
+      tinc-centos-7:  10.10.0.14
+      tinc-centos-8:  10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_leaf_nodes
+
+  - name: tinc-ubuntu-20
+    image: docker.io/library/ubuntu:20.04
+    privileged: true
+    etc_hosts:
+      tinc-ubuntu-16: 10.10.0.11
+      tinc-ubuntu-18: 10.10.0.12
+      tinc-ubuntu-20: 10.10.0.13
+      tinc-centos-7:  10.10.0.14
+      tinc-centos-8:  10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_leaf_nodes

--- a/molecule/star/verify.yml
+++ b/molecule/star/verify.yml
@@ -1,0 +1,1 @@
+../default/verify.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,10 @@
   template:
     src: tinc.systemd.service.j2
     dest: /etc/systemd/system/tinc.service
-  notify: Restart Service
+  notify:
+    - restart service
+    - restart service with systemd
+
   when: ansible_service_mgr == "systemd"
   tags:
     - tinc_install
@@ -46,7 +49,8 @@
   tags:
     - uci
   notify:
-    - Restart Service
+    - restart service
+    - restart service with systemd
 
 - include: tinc_configure.yml
   tags:

--- a/tasks/tinc_configure.yml
+++ b/tasks/tinc_configure.yml
@@ -10,14 +10,16 @@
     content: "{{ tinc_netname }}"
     dest: /etc/tinc/nets.boot
   notify:
-    - Restart Service
+    - restart service
+    - restart service with systemd
 
 - name: ensure tinc.conf contains connection to core nodes
   template:
     src: tinc.conf.j2
     dest: "/etc/tinc/{{ tinc_netname }}/tinc.conf"
   notify:
-    - Restart Service
+    - restart service
+    - restart service with systemd
   tags: connection
 
 - name: create tinc-up file
@@ -26,7 +28,8 @@
     dest: "/etc/tinc/{{ tinc_netname }}/tinc-up"
     mode: 0755
   notify:
-    - Restart Service
+    - restart service
+    - restart service with systemd
 
 - name: create tinc-down file
   template:
@@ -34,7 +37,8 @@
     dest: "/etc/tinc/{{ tinc_netname }}/tinc-down"
     mode: 0755
   notify:
-    - Restart Service
+    - restart service
+    - restart service with systemd
 
 - name: ensure tinc hosts file binds to physical ip address
   lineinfile:
@@ -44,7 +48,8 @@
     create: yes
   when: inventory_hostname in groups['tinc_spine_nodes']
   notify:
-    - Restart Service
+    - restart service
+    - restart service with systemd
 
 - name: ensure subnet ip address is properly set in tinc host file
   lineinfile:
@@ -54,7 +59,8 @@
     create: yes
   when: tinc_mode == 'router'
   notify:
-    - Restart Service
+    - restart service
+    - restart service with systemd
 
 - name: check whether /etc/tinc/netname/hosts/inventory_hostname contains "-----END RSA PUBLIC KEY-----"
   command: awk '/^-----END RSA PUBLIC KEY-----$/'  /etc/tinc/{{ tinc_netname }}/hosts/{{ inventory_hostname | replace('.','_') | replace('-','_') }}
@@ -73,7 +79,8 @@
   args:
     creates: "/etc/tinc/{{ tinc_netname }}/rsa_key.priv"
   notify:
-    - Restart Service
+    - restart service
+    - restart service with systemd
 
 - name: fetch tinc hosts file after key creation
   fetch:
@@ -92,7 +99,8 @@
   when: ansible_os_family != "OpenWrt"
   tags: sync
   notify:
-    - Restart Service
+    - restart service
+    - restart service with systemd
 
 - name: OpenWRT sync the fetched tinc hosts files on each host
   synchronize:
@@ -108,7 +116,8 @@
   tags: sync
   when: ansible_os_family == "OpenWrt"
   notify:
-    - Restart Service
+    - restart service
+    - restart service with systemd
 
 - name: add nodes to /etc/hosts (ansible_inventory resolves to vpn_ip)
   lineinfile:
@@ -120,11 +129,4 @@
   with_items: "{{ play_hosts }}"
   tags:
     - tinc_internal_hosts
-
-# Ensure the systemd daemon is reloaded and the service is restarted
-- meta: flush_handlers
-
-- name: ensure tinc is enabled
-  service:
-    name: "{{ tinc_service_name }}"
-    enabled: yes
+    - molecule-notest # https://github.com/ansible-community/molecule/issues/959

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost ansible_connection=local

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - ansible-tinc


### PR DESCRIPTION
Hi @evrardjp ,
thank you for creating this role. It's really helpful.

My initial purpose was propose the PR for replace the `synchronize` module [here](https://github.com/evrardjp/ansible-tinc/blob/46e8d767716f48bae50a898cf4185a8c040e1960/tasks/tinc_configure.yml#L84) with `copy` - to make this role do not require passwordless sudo.

But beforehand I make the current PR with proposal to update your role by [Molecule tests](https://molecule.readthedocs.io/en/latest/). AFAIK currently you have the automatic syntax check - and I want to propose use Molecule for additional tests. It may check the syntax, run the role simultaneously in several OS, verify idempotency - and finally ensure that each prepared node able to ping other nodes over VPN.

I would be appreciated if you'll find a time to review this idea and related changes proposed to variables, tasks and handlers. Hope that next explanations will be helpful.

Updated [.travis.yml](https://github.com/niluid/ansible-tinc/blob/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/.travis.yml) will run `molecule` command two times and verify:
- `default` scenario for `ring` topology
- the `star` topology as well

Both scenarios described in corresponding [subdirectories](https://github.com/niluid/ansible-tinc/tree/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/molecule/)

We may simply rename `default` to the `ring` - however the currently proposed naming convention allow anybody just execute well-known command `molecule test` in repository root - and this will be enough to run basic test, without necessity additionally check documentation.

`star` scenario re-use the 2/3 playbooks, so the duplicated code defined as softlinks from [molecule/star](https://github.com/niluid/ansible-tinc/tree/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/molecule/star) to [molecule/default](https://github.com/niluid/ansible-tinc/tree/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/molecule/default)

Difference in:
- [default/molecule.yml](https://github.com/niluid/ansible-tinc/blob/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/molecule/default/molecule.yml)
- [star/molecule.yml](https://github.com/niluid/ansible-tinc/blob/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/molecule/star/molecule.yml)

Files are similar except the variables `scenario.name` and `groups`

Current config will spin-up 5 Docker containers, apply the role and execute simple check defined in [verify.yml](https://github.com/niluid/ansible-tinc/blob/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/molecule/default/verify.yml)

I'm not going to recommend run the Tinc VPN on different OSs with different package versions in production - but this might be ok for testing purposes I think.

Docker give some additional specific:
- code `privileged: true` with `command: /sbin/init` in [molecule.yml](https://github.com/niluid/ansible-tinc/blob/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/molecule/default/molecule.yml) enable Systemd on CentOS container. Although Ubuntu here doesn't use Systemd (if necessary, this could be changed by using some other specially prepared Ubuntu images, I think)
- Docker images lack some standard software, so [converge.yml](https://github.com/niluid/ansible-tinc/blob/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/molecule/default/converge.yml) take care about installing necessary dependencies
- https://github.com/ansible-community/molecule/issues/959 say that Docker doesn't let us modify /etc/hosts in a container. To workaround this I added `molecule-notest` tag to [this task](https://github.com/niluid/ansible-tinc/blob/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/tasks/tinc_configure.yml#L122) and instead /etc/hosts will be modified during container creation - as configured by `etc_hosts` directives in [molecule.yml](https://github.com/niluid/ansible-tinc/blob/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/molecule/default/molecule.yml) 

After failing first tests I found that on CentOS containers Tinc additionally required manual execution of `systemctl restart tinc`. Maybe I missed something in [corresponding conversation](https://github.com/evrardjp/ansible-tinc/pull/4#discussion_r243597519) but my assumption was that currently [these handlers](https://github.com/evrardjp/ansible-tinc/blob/46e8d767716f48bae50a898cf4185a8c040e1960/handlers/main.yml) may doesn't work as expected. I think, that on systems with Systemd this code may trigger only `systemd daemon-reload` and Ansible may not restart the service afterwise. Not sure, maybe it's depends on Ansible version through.

Instead I want propose [updated handlers](https://github.com/niluid/ansible-tinc/blob/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/handlers/main.yml) which will be triggered [by this code](https://github.com/niluid/ansible-tinc/blob/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/tasks/tinc_configure.yml#L12). I  have to agree that two-rows call is not ideal and would be great if somebody will propose something more laconic.

As I added `enabled: yes` to service description in handlers - this PR propose to remove last two tasks from [tinc_configure.yml](https://github.com/evrardjp/ansible-tinc/blob/46e8d767716f48bae50a898cf4185a8c040e1960/tasks/tinc_configure.yml#L124)
I tried to imagine scenarios when we the settings in handlers will not be enough - and I can't propose anything. Please correct if I'm wrong.

Updated [defaults/main.yml](https://github.com/evrardjp/ansible-tinc/compare/master...niluid:master#diff-23e21b6c89468f7534697ad091835b3ee5e0213b37ace489488234e5a9548ec4):
- remove the variable `service_name` (I found it only in handlers and replaced with existing `tinc_service_name`)
- define defaults for `tinc_netname` and `tinc_control_plane_bind_ip` - they required during Molecule execution.

This PR remove the [tests](https://github.com/evrardjp/ansible-tinc/tree/46e8d767716f48bae50a898cf4185a8c040e1960/tests) folder used by original [.travis.yml](https://github.com/evrardjp/ansible-tinc/blob/46e8d767716f48bae50a898cf4185a8c040e1960/.travis.yml)

This PR update [meta/main.yml](https://github.com/niluid/ansible-tinc/tree/2cd48cb79ff96fffb06e6193b2df6cd79ec470aa/meta/main.yml) - after passing the tests I've extended the list of supported Ubuntu/CentOS systems in this file.

Thanks again for your time.
Looking forward for your feedback. 

