### PR TITLE
Added Molecule tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,15 @@
 ---
+os: linux
+dist: focal
 language: python
-python: "2.7"
-
-# Use the new container infrastructure
-sudo: required
-dist: trusty
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
-
+python: 3.8
+services:
+  - docker
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
-
+  - python3 -m pip install molecule
+  - python3 -m pip install molecule-docker
+  - python3 -m pip install ansible
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
-
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  - molecule --version
+  - molecule test # default scenario with ring topology
+  - molecule test -s star

--- a/README.md
+++ b/README.md
@@ -76,6 +76,49 @@ node2
 node1
 ```
 
+Testing
+-------
+Tests based on Ansible Molecule framework which doing next:
+- check role syntax
+- start several containers with different OS <i>(only for tests. We don't mix Tinc versions in production)</i>
+- apply this role to each container
+- verify idempotency (make sure that second run will not make unexpected changes)
+- verify that each prepared node able to ping other nodes over VPN
+
+Tests run in a Travis. Additionally you may execute them on local machine.
+
+Dependencies you need to have installed for running the tests:
+- Ansible
+- [Docker](https://docs.docker.com/engine/install/)
+- [Molecule](https://molecule.readthedocs.io/en/latest/installation.html) with `molecule-docker` driver
+
+How to run existing tests for star and ring topologies:
+```bash
+cd ansible-tinc
+molecule test # this run default tests for Ring scenario
+molecule test -s star
+```
+
+The 'molecule test' command execute full scenario: 'create', 'converge', 'check idempotency', 'verify' and 'destroy' steps. Often you don't want to have container immediately destroyed and need access it for debug. For this might be useful replace 'molecule test' with:
+
+```bash
+molecule converge # this create containers and apply the role
+molecule verify # run tests described in molecule/default/verify.yml
+
+# after both steps you have live Docker containers
+# you can access them with usual commands 'docker ps', 'docker exec' etc
+
+molecule destroy
+```
+
+How to test role with new OS:
+
+add new image to [molecule/default/molecule.yml](molecule/default/molecule.yml) and [molecule/star/molecule.yml](molecule/star/molecule.yml) following existing examples. Files are similar except the variables `scenario.name` and `groups`. Next hightlights could be hepful:
+
+- code `privileged: true` with `command: /sbin/init` enable systemd if container  support it. Please don't forget that privileged containers in your system could be a risk.
+- Docker images lack some standard software, so [molecule/default/converge.yml](molecule/default/converge.yml) take care about installing necessary dependencies
+- according with https://github.com/ansible-community/molecule/issues/959 Docker doesn't allow modify /etc/hosts in a container. To workaround this we skipping one step with `molecule-notest` tag in [tasks/tinc_configure.yml](tasks/tinc_configure.yml) and modifying /etc/hosts during container creation - following the corresponding directives in [molecule/default/molecule.yml](molecule/default/molecule.yml)
+
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,5 @@ tinc_mode: router
 tinc_vpn_interface: tun0
 # tinc_vpn_cidr is set to /32 when tinc_mode: router - this will be overridden
 tinc_vpn_cidr: "/24"
+tinc_netname: tinc-vpn
+tinc_control_plane_bind_ip: "{{ ansible_default_ipv4.address }}"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,31 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: yes
+  tasks:
+
+  - name: Apt update and install rsync, ping, iproute
+    apt:
+      update_cache: yes
+      name:
+        - rsync
+        - inetutils-ping
+        - iproute2
+      state: present
+    when: ansible_os_family == "Debian"
+
+  - name: Yum install iproute to fix undefined ansible_default_ipv4.address
+    yum:
+      name: iproute
+      state: present
+    when:
+      - ansible_distribution == "CentOS"
+      - ansible_distribution_major_version == "7"
+
+  - name: Re-collect network facts required after installation iproute
+    setup:
+      gather_subset: network
+
+  - name: Include ansible-tinc
+    include_role:
+      name: ansible-tinc

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,97 @@
+---
+scenario:
+  name: default # ring topology
+dependency:
+  name: galaxy
+driver:
+  name: docker
+verifier:
+  name: ansible
+provisioner:
+  name: ansible
+  log: false
+  inventory:
+    host_vars:
+      tinc-centos-7:
+        tinc_vpn_ip: 10.10.0.11
+      tinc-centos-8:
+        tinc_vpn_ip: 10.10.0.12
+      tinc-ubuntu-16:
+        tinc_vpn_ip: 10.10.0.13
+      tinc-ubuntu-18:
+        tinc_vpn_ip: 10.10.0.14
+      tinc-ubuntu-20:
+        tinc_vpn_ip: 10.10.0.15
+platforms:
+  - name: tinc-centos-7
+    image: docker.io/pycontribs/centos:7
+    pre_build_image: true
+    privileged: true
+    command: /sbin/init
+    etc_hosts:
+      tinc-centos-7:  10.10.0.11
+      tinc-centos-8:  10.10.0.12
+      tinc-ubuntu-16: 10.10.0.13
+      tinc-ubuntu-18: 10.10.0.14
+      tinc-ubuntu-20: 10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes
+  - name: tinc-centos-8
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+    privileged: true
+    command: /sbin/init
+    etc_hosts:
+      tinc-centos-7:  10.10.0.11
+      tinc-centos-8:  10.10.0.12
+      tinc-ubuntu-16: 10.10.0.13
+      tinc-ubuntu-18: 10.10.0.14
+      tinc-ubuntu-20: 10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes
+  - name: tinc-ubuntu-16
+    image: diodonfrost/ubuntu-16.04-ansible
+    pre_build_image: true
+    privileged: true
+    etc_hosts:
+      tinc-centos-7:  10.10.0.11
+      tinc-centos-8:  10.10.0.12
+      tinc-ubuntu-16: 10.10.0.13
+      tinc-ubuntu-18: 10.10.0.14
+      tinc-ubuntu-20: 10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes
+  - name: tinc-ubuntu-18
+    image: diodonfrost/ubuntu-18.04-ansible
+    pre_build_image: true
+    privileged: true
+    etc_hosts:
+      tinc-centos-7:  10.10.0.11
+      tinc-centos-8:  10.10.0.12
+      tinc-ubuntu-16: 10.10.0.13
+      tinc-ubuntu-18: 10.10.0.14
+      tinc-ubuntu-20: 10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes
+  - name: tinc-ubuntu-20
+    image: diodonfrost/ubuntu-20.04-ansible
+    pre_build_image: true
+    privileged: true
+    etc_hosts:
+      tinc-centos-7:  10.10.0.11
+      tinc-centos-8:  10.10.0.12
+      tinc-ubuntu-16: 10.10.0.13
+      tinc-ubuntu-18: 10.10.0.14
+      tinc-ubuntu-20: 10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: no
+  tasks:
+
+  - name: Ping other nodes over VPN
+    command: "ping -c 1 {{ item }}"
+    with_items: "{{ play_hosts }}"
+    when: item != inventory_hostname

--- a/molecule/star/converge.yml
+++ b/molecule/star/converge.yml
@@ -1,0 +1,1 @@
+../default/converge.yml

--- a/molecule/star/molecule.yml
+++ b/molecule/star/molecule.yml
@@ -1,0 +1,96 @@
+---
+scenario:
+  name: star
+dependency:
+  name: galaxy
+driver:
+  name: docker
+verifier:
+  name: ansible
+provisioner:
+  name: ansible
+  log: false
+  inventory:
+    host_vars:
+      tinc-centos-7:
+        tinc_vpn_ip: 10.10.0.11
+      tinc-centos-8:
+        tinc_vpn_ip: 10.10.0.12
+      tinc-ubuntu-16:
+        tinc_vpn_ip: 10.10.0.13
+      tinc-ubuntu-18:
+        tinc_vpn_ip: 10.10.0.14
+      tinc-ubuntu-20:
+        tinc_vpn_ip: 10.10.0.15
+platforms:
+  - name: tinc-centos-7
+    image: docker.io/pycontribs/centos:7
+    pre_build_image: true
+    privileged: true
+    command: /sbin/init
+    etc_hosts:
+      tinc-centos-7:  10.10.0.11
+      tinc-centos-8:  10.10.0.12
+      tinc-ubuntu-16: 10.10.0.13
+      tinc-ubuntu-18: 10.10.0.14
+      tinc-ubuntu-20: 10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_spine_nodes
+      - tinc_leaf_nodes
+  - name: tinc-centos-8
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+    privileged: true
+    command: /sbin/init
+    etc_hosts:
+      tinc-centos-7:  10.10.0.11
+      tinc-centos-8:  10.10.0.12
+      tinc-ubuntu-16: 10.10.0.13
+      tinc-ubuntu-18: 10.10.0.14
+      tinc-ubuntu-20: 10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_leaf_nodes
+
+  - name: tinc-ubuntu-16
+    image: diodonfrost/ubuntu-16.04-ansible
+    pre_build_image: true
+    privileged: true
+    etc_hosts:
+      tinc-centos-7:  10.10.0.11
+      tinc-centos-8:  10.10.0.12
+      tinc-ubuntu-16: 10.10.0.13
+      tinc-ubuntu-18: 10.10.0.14
+      tinc-ubuntu-20: 10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_leaf_nodes
+
+  - name: tinc-ubuntu-18
+    image: diodonfrost/ubuntu-18.04-ansible
+    pre_build_image: true
+    privileged: true
+    etc_hosts:
+      tinc-centos-7:  10.10.0.11
+      tinc-centos-8:  10.10.0.12
+      tinc-ubuntu-16: 10.10.0.13
+      tinc-ubuntu-18: 10.10.0.14
+      tinc-ubuntu-20: 10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_leaf_nodes
+
+  - name: tinc-ubuntu-20
+    image: diodonfrost/ubuntu-20.04-ansible
+    pre_build_image: true
+    privileged: true
+    etc_hosts:
+      tinc-centos-7:  10.10.0.11
+      tinc-centos-8:  10.10.0.12
+      tinc-ubuntu-16: 10.10.0.13
+      tinc-ubuntu-18: 10.10.0.14
+      tinc-ubuntu-20: 10.10.0.15
+    groups:
+      - tinc_nodes
+      - tinc_leaf_nodes

--- a/molecule/star/verify.yml
+++ b/molecule/star/verify.yml
@@ -1,0 +1,1 @@
+../default/verify.yml

--- a/tasks/tinc_configure.yml
+++ b/tasks/tinc_configure.yml
@@ -120,6 +120,7 @@
   with_items: "{{ play_hosts }}"
   tags:
     - tinc_internal_hosts
+    - molecule-notest # https://github.com/ansible-community/molecule/issues/959
 
 # Ensure the systemd daemon is reloaded and the service is restarted
 - meta: flush_handlers

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost ansible_connection=local

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - ansible-tinc


### PR DESCRIPTION
Hi. As discussed in https://github.com/evrardjp/ansible-tinc/pull/51 I would propose the separate PR describing the Molecule tests.

Updated .travis.yml execute `molecule` command two times and verify:
- `default` scenario for `ring` topology
- the `star` topology as well

Current config will spin-up 5 Docker containers, apply the role and execute simple check defined in molecule/default/verify.yml
 - each node attempt to ping other nodes over VPN.

CentOS images choosed from Molecule defaults.
Ubuntu images chosed after the tests of several Docker images, which support Systemd.
I'm not propose the image for OpenWRT as I'm not familiar with this system, sorry.

Warning:
This pull request set build status to failed, because after run Ansible 2.10 execute only first one handler from the list defined in https://github.com/evrardjp/ansible-tinc/blob/f876fc5c2fbba8735a407801ae5f1db0d657bdf2/handlers/main.yml
Let to know please if solution should be proposed as part of the same PR.

Regards,