### PR TITLE
Fixups for running in switch mode

### DIFF
--- a/tasks/tinc_configure.yml
+++ b/tasks/tinc_configure.yml
@@ -60,6 +60,7 @@
   command: awk '/^-----END RSA PUBLIC KEY-----$/'  /etc/tinc/{{ tinc_netname }}/hosts/{{ inventory_hostname | replace('.','_') | replace('-','_') }}
   changed_when: "public_key.stdout != '-----END RSA PUBLIC KEY-----'"
   register: public_key
+  ignore_errors: yes
 
 # this is necessary because the public key will not be generated (non-interactively) if the private key already exists
 - name: delete private key and regenerate keypair if public key is absent from tinc hosts file

--- a/templates/tinc.conf.j2
+++ b/templates/tinc.conf.j2
@@ -2,6 +2,7 @@ Name = {{ inventory_hostname | replace('.','_') | replace('-','_') }}
 {% if tinc_address_family is defined %}
 AddressFamily = {{ tinc_address_family }}
 {% endif %}
+Mode = {{ tinc_mode }}
 Interface = {{ tinc_vpn_interface }}
 {% for host in groups['tinc_spine_nodes'] %}
 {% if inventory_hostname != hostvars[host]['inventory_hostname'] and inventory_hostname in groups['tinc_leaf_nodes'] %}


### PR DESCRIPTION
I needed to make the following changes to get a VPN up and running in switch mode
* Actually set the mode in tinc.conf
* Skip errors on the initial check for an RSA key already being present. For leaf nodes the `host` file will not have been created yet, so the `awk` command fails. There may be a better way to accomplish this. 