### PR TITLE
Trigger restart service on host key change

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,6 +98,8 @@
     mode: 0755
   loop: "{{ ansible_play_batch }}"
   when: item != inventory_hostname
+  notify:
+    - Restart Service
 
 - name: Add nodes to /etc/hosts
   lineinfile:


### PR DESCRIPTION
Without this patch, a change in an host wouldn't get noticed.
This fixes it by ensuring a change in the upload would trigger
a restart of the service.
