### PR TITLE
Clarify scenario naming

### DIFF
--- a/.github/workflows/molecule-test.yaml
+++ b/.github/workflows/molecule-test.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ansible: ["2.9", "latest"]
-        topology: ["ring", "star"]
+        scenario: ["ring", "star"]
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -19,4 +19,4 @@ jobs:
           sudo apt install tox
       - name: Test with molecule using tox
         run: |
-          sudo -H -E tox -e ansible-${{ matrix.ansible }}-${{ matrix.topology }}
+          sudo -H -E tox -e ansible-${{ matrix.ansible }}-${{ matrix.scenario }}


### PR DESCRIPTION
The name of the github worklow might lead to think that this is
intended to test different topologies, and not different scenarios
from tox.

This should clarify it.
