### PR TITLE
Avoid failure when starting instance because OpenWRT doesn't have bash

### DIFF
--- a/molecule/openwrt/molecule.yml
+++ b/molecule/openwrt/molecule.yml
@@ -24,6 +24,7 @@ provisioner:
 platforms:
   - name: tinc-openwrt-1
     image: openwrtorg/rootfs
+    command: ""
     pre_built_image: True
     etc_hosts:
       tinc-openwrt-1:  10.10.0.11
@@ -35,6 +36,7 @@ platforms:
       
   - name: tinc-openwrt-2
     image: openwrtorg/rootfs
+    command: ""
     pre_built_image: True
     etc_hosts:
       tinc-openwrt-1:  10.10.0.11


### PR DESCRIPTION
This should solve your problem with running the OpenWRT image via Molecule. It doesn't make the test pass yet but the resulting error seems not to be caused by Molecule.

Hope it helps