### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.DS_Store
 hosts
 *.retry
-fetch/
+*.log
+.cache


### PR DESCRIPTION
The last changes removed the fetch/ folder, but we still
have it in gitignore.

This can be removed now.

Additionally, our testing can create a .cache folder.
There is no need for this to be checked in git.
