### PR TITLE
Fix openwrt build

### DIFF
--- a/molecule/openwrt/converge.yml
+++ b/molecule/openwrt/converge.yml
@@ -1,22 +1,7 @@
 - name: Converge
   hosts: all
-  gather_facts: no
+  gather_facts: yes
   tasks:
-
-  - name: Update pkg metadata
-    raw: opkg update #noqa no-changed-when
-    tags:
-      - skip_ansible_lint
-
-  - name: Install python3
-    raw: opkg install python3 #noqa no-changed-when
-    tags:
-      - skip_ansible_lint
-    
-  - name: Re-collect network facts required after installation of python
-    setup:
-      gather_subset: network
-
   - name: Include ansible-tinc
     include_role:
       name: ansible-tinc

--- a/molecule/openwrt/molecule.yml
+++ b/molecule/openwrt/molecule.yml
@@ -33,7 +33,7 @@ platforms:
       - tinc_nodes
       - tinc_spine_nodes
       - tinc_leaf_nodes
-      
+
   - name: tinc-openwrt-2
     image: openwrtorg/rootfs
     command: ""
@@ -44,4 +44,4 @@ platforms:
     groups:
       - tinc_nodes
       - tinc_spine_nodes
-      - tinc_leaf_nodes      
+      - tinc_leaf_nodes

--- a/molecule/openwrt/prepare.yml
+++ b/molecule/openwrt/prepare.yml
@@ -1,0 +1,14 @@
+- name: Prepare
+  hosts: all
+  gather_facts: no
+  tasks:
+
+  - name: Update pkg metadata
+    raw: opkg update #noqa no-changed-when
+    tags:
+      - skip_ansible_lint
+
+  - name: Install python3
+    raw: opkg install python3 #noqa no-changed-when
+    tags:
+      - skip_ansible_lint

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,12 +79,21 @@
     #Ansible lint recommends this to be handler, but this would make the role more complex.
     - skip_ansible_lint
 
-- name: Create tinc private key (and append public key to tincd hosts file)
-  command: "tincd -n {{ tinc_netname }} -K{{ tinc_key_size }}"
-  args:
-    creates: "/etc/tinc/{{ tinc_netname }}/rsa_key.priv"
-  notify:
-    - Restart Service
+- name: Generate tinc keys and append public key to host file
+  block:
+    - name: Create using tincd -K
+      command: "tincd -n {{ tinc_netname }} -K{{ tinc_key_size }}"
+      args:
+        creates: "/etc/tinc/{{ tinc_netname }}/rsa_key.priv"
+      notify:
+        - Restart Service
+  rescue:
+    - name: Create using tinc client
+      command:  "tinc -n {{ tinc_netname }} generate-keys {{ tinc_key_size }}"
+      args:
+        creates: "/etc/tinc/{{ tinc_netname }}/rsa_key.priv"
+      notify:
+        - Restart Service
 
 - name: Get tinc hosts file after key creation
   slurp:
@@ -125,7 +134,7 @@
     - uci
   notify:
     - Restart Service
-  
+
 - name: Ensure tinc is enabled
   service:
     name: "{{ tinc_service_name }}@{{ tinc_netname }}"


### PR DESCRIPTION
On openwrt, the command tincd -K isn't available.
In the past (before the last refactor removing fetch), it wasn't
a problem, as the keys could be generated by the admin on first use,
and then sent to the rest of the cluster from the fetched folder.

The last refactor broke this, and so we need to properly generate
the files and then transfer them

This should fix it.
