### PR TITLE
Add leaves nodes in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,17 @@ Please have a look in the task files.
 ```
 [tinc_nodes:children]
 tinc_spine_nodes
+tinc_leaf_nodes
 
 [tinc_spine_nodes]
 node1 tinc_vpn_ip=10.10.0.11
 node2 tinc_vpn_ip=10.10.0.12
 node3 tinc_vpn_ip=10.10.0.13
+
+[tinc_leaf_nodes]
+node1
+node2
+node3
 ```
 ### Router mode, star topology
 
@@ -63,6 +69,11 @@ node3
 
 [tinc_spine_nodes]
 node1
+
+[tinc_leaf_nodes]
+node1
+node2
+node3
 ```
 
 Group vars for `tinc_nodes`:


### PR DESCRIPTION
If you strictly follow the README without checking the description,
you won't define the leaf nodes group, and it will not work.

This is a problem, as ppl think the role is broken.

This fixes it by giving a more complete example.


-----
[View rendered README.md](https://github.com/evrardjp/ansible-tinc/blob/fix-readme/README.md)